### PR TITLE
Add gcc and gdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update && apk upgrade
 RUN apk --no-cache add busybox-suid openssh-server
 RUN apk --no-cache add zsh nano curl man man-pages
 RUN apk --no-cache add python3 nmap nmap-scripts tcpdump sudo
+RUN apk --no-cache add gcc musl-dev gdb
 
 RUN echo 'root:qczqdupe9vsiy5cxg923mwiyxm8fkh8' | chpasswd
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Works with [thuv](https://github.com/gandem/thuv).
 ## Commands
 
 - Build: `docker build -t ssi_tuto .`
-- Run: `docker run -it --rm -p 3000:22 ssi_tuto <login> <passwd>`
+- Run: `docker run -it --rm --security-opt seccomp=unconfined -p 3000:22 ssi_tuto <login> <passwd>`
 - SSH: `ssh -p 3000 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null <login>@0.0.0.0`
 - tests: `ssh -p 3000 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t root@0.0.0.0 '/usr/local/tests/tests.sh'`

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -13,3 +13,17 @@ python3 /usr/local/tests/hash.py
 # nmap
 echo "nmap"
 nmap -A www.centralesupelec.fr
+
+# gcc
+echo "gcc"
+echo "
+int main() {
+    return 0;
+}" > test.c
+gcc test.c -o test
+
+# gdb
+echo "gdb"
+gdb -batch -ex "run" test 2>&1
+rm -f test
+rm -f test.c


### PR DESCRIPTION

Notes: 

- To be able to compile C programs, `musl-dev` is needed on top of `gcc`,

- The `--security-opt seccomp=unconfined` option is necessary when running the container. Without it, using the `run` command in `gdb` fails because disabling address space randomization is not permitted inside the container.